### PR TITLE
Change conference logos

### DIFF
--- a/img/ches.svg
+++ b/img/ches.svg
@@ -5,11 +5,11 @@
     <style type="text/css"><![CDATA[
     .ches {
     font: bold 30px sans-serif;
-    fill: blue;
+    fill: #102a83; /* pale teal */
     }
     ]]></style>
   </defs>
-  <rect x="0" y="0" height="100" width="100" stroke="blue" fill="white" stroke-width="2"/>
+  <rect x="0" y="0" height="100" width="100" stroke="none" fill="#b2d8d8" stroke-width="2"/>
   <text x="50" y="60" text-anchor="middle" class="ches">CHES</text>
 </svg>
 

--- a/img/fse.svg
+++ b/img/fse.svg
@@ -5,11 +5,11 @@
     <style type="text/css"><![CDATA[
     .ches {
     font: bold 30px sans-serif;
-    fill: blue;
+    fill: #102a83; /* pale teal */
     }
     ]]></style>
   </defs>
-  <rect x="0" y="0" height="100" width="100" stroke="blue" fill="white" stroke-width="2"/>
+  <rect x="0" y="0" height="100" width="100" stroke="none" fill="#b2d8d8" stroke-width="2"/>
   <text x="50" y="60" text-anchor="middle" class="ches">FSE</text>
 </svg>
 

--- a/img/pkc.svg
+++ b/img/pkc.svg
@@ -5,11 +5,11 @@
     <style type="text/css"><![CDATA[
     .ches {
     font: bold 30px sans-serif;
-    fill: blue;
+    fill: #102a83; /* pale teal */
     }
     ]]></style>
   </defs>
-  <rect x="0" y="0" height="100" width="100" stroke="blue" fill="white" stroke-width="2"/>
+  <rect x="0" y="0" height="100" width="100" stroke="none" fill="#b2d8d8" stroke-width="2"/>
   <text x="50" y="60" text-anchor="middle" class="ches">PKC</text>
 </svg>
 

--- a/img/tcc.svg
+++ b/img/tcc.svg
@@ -5,11 +5,11 @@
     <style type="text/css"><![CDATA[
     .ches {
     font: bold 30px sans-serif;
-    fill: blue;
+    fill: #102a83; /* pale teal */
     }
     ]]></style>
   </defs>
-  <rect x="0" y="0" height="100" width="100" stroke="blue" fill="white" stroke-width="2"/>
+  <rect x="0" y="0" height="100" width="100" stroke="none" fill="#b2d8d8" stroke-width="2"/>
   <text x="50" y="60" text-anchor="middle" class="ches">TCC</text>
 </svg>
 

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/UCSB.jpg" alt="University of California, Santa Barbara" class="img-fluid" />
+                <img src="img/UCSB.jpg" alt="University of California, Santa Barbara" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -183,7 +183,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/asia_pacific.png" alt="Asia-Pacific Region" class="img-fluid" />
+                <img src="img/asia_pacific.png" alt="Asia-Pacific Region" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -196,7 +196,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/europe.png" alt="Europe" class="img-fluid" />
+                <img src="img/europe.png" alt="Europe" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -213,7 +213,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/ches.svg" alt="Cryptographic Hardware and Embedded Systems Conference" class="img-fluid" />
+                <img src="img/ches.svg" alt="Cryptographic Hardware and Embedded Systems Conference" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -226,7 +226,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/tcc.svg" alt="Theory of Cryptography Conference" class="img-fluid" />
+                <img src="img/tcc.svg" alt="Theory of Cryptography Conference" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -239,7 +239,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/fse.svg" alt="Fast Software Encryption Conference" class="img-fluid" />
+                <img src="img/fse.svg" alt="Fast Software Encryption Conference" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -252,7 +252,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/pkc.svg" alt="Public Key Cryptography Conference" class="img-fluid" />
+                <img src="img/pkc.svg" alt="Public Key Cryptography Conference" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -267,7 +267,7 @@
           <div class="card mb-2">
             <div class="row no-gutters">
               <div class="col-auto">
-                <img src="img/rwc.png" alt="Real World Crypto" class="img-fluid" />
+                <img src="img/rwc.png" alt="Real World Crypto" class="img-fluid img-thumbnail" />
               </div>
               <div class="col">
                 <div class="card-block px-2">
@@ -335,7 +335,7 @@
         <div class="card mb-2">
           <div class="row no-gutters">
             <div class="col-auto">
-              <img src="img/publications1.png" width="150" alt="IACR Publications" class="img-fluid" />
+              <img src="img/publications1.png" width="150" alt="IACR Publications" class="img-fluid img-thumbnail" />
             </div>
             <div class="col">
               <div class="card-block px-2">


### PR DESCRIPTION
This makes the icons for tcc, fse, ches, and pkc have a background pale teal and font color the same as the logo. See  https://iacr.org/tools/logo/iacrmain2/